### PR TITLE
수정계 대응

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-monolith/pxt-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "files": [
     "README.md",
     "built/*.js",

--- a/pxtlib/codle/cookie.ts
+++ b/pxtlib/codle/cookie.ts
@@ -15,7 +15,8 @@ namespace pxt.cookie {
   export function getEnv(): string {
     return window.location.hostname === "localhost"
       ? "local"
-      : window.location.hostname.includes("dev")
+      : window.location.hostname.includes("dev") ||
+        window.location.hostname.includes("revised")
       ? "dev"
       : "prd";
   }


### PR DESCRIPTION
[이슈 스레드](https://monolith-keb2010.slack.com/archives/C04F0S33HCL/p1729003617196779)

수정계 (`revised`) 도메인을 대응합니다.