### PR TITLE
TASK-3204 메이크코드 재검정계 대응 쿠키설정 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-monolith/pxt-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "files": [
     "README.md",
     "built/*.js",

--- a/pxtlib/codle/cookie.ts
+++ b/pxtlib/codle/cookie.ts
@@ -13,18 +13,19 @@ namespace pxt.cookie {
   }
 
   export function getEnv(): string {
-    return window.location.hostname === "localhost"
+    const splitedHostNames = window.location.hostname.split(".");
+    return splitedHostNames.includes("localhost")
       ? "local"
-      : window.location.hostname.includes("dev") ||
-        window.location.hostname.includes("revised")
+      : splitedHostNames.includes("dev") || splitedHostNames.includes("revised") || splitedHostNames.includes("ver")
       ? "dev"
       : "prd";
   }
 
-  export function getCookieName(name: string): string {
+  export function getCookieName(name: string): string { 
     if (window.location.hostname === "localhost") {
       return `${name}_localhost_local`;
     }
+    // hostname example: "makecode.2v8p.aidt.me"
     const tenant = window.location.hostname.split(".")[1];
     return `${name}_${tenant}_${getEnv()}`;
   }

--- a/pxtlib/codle/cookie.ts
+++ b/pxtlib/codle/cookie.ts
@@ -21,7 +21,7 @@ namespace pxt.cookie {
       : "prd";
   }
 
-  export function getCookieName(name: string): string { 
+  export function getCookieName(name: string): string {
     if (window.location.hostname === "localhost") {
       return `${name}_localhost_local`;
     }


### PR DESCRIPTION
1. hostname에 ver이 들어갈 시 env가 "dev"로 판단될 수 있도록 합니다.
2. 기존 getEnv 함수 로직이 hostname 전체에 키워드 포함 여부로 판단했기 때문에 잘못 판단될 가능성이 있었습니다.
ex) 만약 어떤 aidt tenant가 "dev3"이라면 dev로 판단됨
그래서 `.`으로 split한 hostname들 중 키워드 일치 여부를 보도록 로직을 개선했습니다.