### PR TITLE
TASK-5598 Cloud.apiRoot origin 복원

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-monolith/pxt-core",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5986,24 +5986,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     };
     pxt.docs.requireMarked = () => require("marked");
 
-    /*
     // allow static web site to specify custom backend
     if (pxt.appTarget.cloud?.apiRoot)
         Cloud.apiRoot = pxt.appTarget.cloud.apiRoot
     else {
         const hm = /^(https:\/\/[^/]+)/.exec(window.location.href)
         if (hm) Cloud.apiRoot = hm[1] + "/api/"
-    }
-    */
-
-    // 테넌트에 맞게 class rails apiRoot를 설정합니다.
-    const hostname = window.location.hostname;
-    if (hostname === "localhost") {
-        Cloud.apiRoot = ""; // FIXME: 로컬호스트에서 테스팅할 백엔드 주소를 입력해주세요.
-    } else {
-        const parts = hostname.split(".");
-        const classRailsUrl = `https://class.${parts.slice(1).join(".")}`;
-        Cloud.apiRoot = `${classRailsUrl}/makecode/`;
     }
 
     if (query["hw"]) {


### PR DESCRIPTION
## 배경

### 발단
[이동연 슬랙](https://monolith-keb2010.slack.com/archives/C086HAVUFR8/p1775636234.580269)에서 jce-class-rails의 makecode 사용자 프로젝트 API에 대한 리뷰가 시작되었고, 그 과정에서 다음 사실들이 확인되었습니다.

1. **Backend 정리 작업 중**: jce-class-rails에서 `/makecode/api/user/project*` 엔드포인트와 `version`(Optimistic Locking) 필드를 제거하는 작업이 진행 중
2. **pxt 영향 조사 필요**: pxt에 잔존하는 cloud sync 코드가 BE 제거에 영향을 받는지 확인 요청
3. **현재 우리는 controller mode만 사용**: pxt를 iframe으로 임베딩(`?controller=1`)하여 사용하며, cloud 모드는 사용하지 않음

### 1차 분석 결과 (cloud.ts 전체 삭제 시도)
- pxt에서 cloud sync 코드가 controller mode에서 dead code임을 확인
- 처음에는 dead code 정리 차원에서 `cloud.ts` 전체 삭제 + 호출부 정리 PR(#12)을 작성
- **9개 파일 / +22 / -914 라인**

### 방향 전환 ([이창환 피드백](https://monolith-keb2010.slack.com/archives/C086HAVUFR8/p1775712868117219))
이창환님으로부터 다음 피드백을 받았습니다.

> cloud 코드를 제거 하면 origin 과의 차이가 너무 커지는데 어떤 이익이 기대되어 작업하신건가요?
> 다음주 작업이 바로 origin 따라 잡으셔야 하는 작업인데
> 우리가 cloud 를 위해 조작한 추가 코드를 제거해서 origin이랑 더 맞춘건가요?
> 제 기억에는 cloud를 위해 class-rails를 주입하는 등, 이상한 짓을 pxt에 좀 했습니다. 따라서 전 이 기회에 우리가 cloud를 억지로 쓰기 위해 만든 차이를 제거하고 다시 origin 과 더 비슷해질 수 있다고 생각합니다

이에 따라 작업 방향을 다음과 같이 재정의했습니다.

- **우선 가치**: origin(microsoft/pxt)과의 격차 최소화
- **목표**: 이전 동작과 동일하되, 런타임 에러 가능성 없이 origin과의 차이를 줄이는 것
- **대상**: 우리가 cloud를 억지로 쓰기 위해 추가했던 커스텀 코드만 제거

## 무엇을 변경했나

### 변경 위치: `webapp/src/app.tsx` (-12줄)

`Cloud.apiRoot`를 설정하는 부분에서, **테넌트별 class-rails URL을 동적으로 생성하는 커스텀 코드를 제거**하고 origin의 apiRoot 로직을 복원했습니다.

#### 제거한 커스텀 코드
```typescript
/*
// allow static web site to specify custom backend
if (pxt.appTarget.cloud?.apiRoot)
    Cloud.apiRoot = pxt.appTarget.cloud.apiRoot
else {
    const hm = /^(https:\/\/[^/]+)/.exec(window.location.href)
    if (hm) Cloud.apiRoot = hm[1] + "/api/"
}
*/

// 테넌트에 맞게 class rails apiRoot를 설정합니다.
const hostname = window.location.hostname;
if (hostname === "localhost") {
    Cloud.apiRoot = ""; // FIXME: 로컬호스트에서 테스팅할 백엔드 주소를 입력해주세요.
} else {
    const parts = hostname.split(".");
    const classRailsUrl = \`https://class.\${parts.slice(1).join(\".\")}\`;
    Cloud.apiRoot = \`\${classRailsUrl}/makecode/\`;
}
```

#### 복원한 origin 코드
```typescript
// allow static web site to specify custom backend
if (pxt.appTarget.cloud?.apiRoot)
    Cloud.apiRoot = pxt.appTarget.cloud.apiRoot
else {
    const hm = /^(https:\/\/[^/]+)/.exec(window.location.href)
    if (hm) Cloud.apiRoot = hm[1] + "/api/"
}
```

## 왜 이 변경이 안전한가

### 호출 경로 분석
controller mode에서 pxt가 동작하는 방식:

1. URL에 `?controller=1` 파라미터가 있으면 `pxt.shell.isControllerMode()`가 `true` 반환
2. `webapp/src/app.tsx`에서 controller mode 진입 시 `pxt.auth.enableAuth(false)` 호출
3. `pxtlib/auth.ts`의 `authDisabled` 플래그가 `true`로 설정됨
4. `hasIdentity()` 함수가 `!authDisabled && ...`를 평가하여 **`false` 반환**

### `Cloud.apiRoot`를 사용하는 cloud sync 코드 진입 차단
`webapp/src/cloud.ts`의 `syncAsync()`는 origin 코드 그대로 다음과 같은 가드를 가지고 있습니다.

```typescript
export async function syncAsync(opts?: SyncAsyncOptions): Promise<pxt.workspace.Header[]> {
    if (!auth.hasIdentity()) { return []; }   // ← controller mode에서 즉시 return
    if (!auth.loggedIn()) { return []; }
    ...
}
```

따라서 controller mode에서는 `syncAsync()` 진입 자체가 불가능하며, `Cloud.apiRoot`를 사용하는 모든 API 호출(`/api/user/project`, `/api/user/project/share` 등)에 도달할 수 없습니다.

### 결론
`Cloud.apiRoot`의 값이 무엇이든 controller mode에서는 cloud API 호출이 발생하지 않으므로, class-rails 커스텀 설정은 **불필요한 추가 코드**입니다. 이를 origin 코드로 복원하면 origin 격차를 12줄 줄일 수 있습니다.

## 동작 보장

### 이전 동작과의 동일성
- **Cloud sync 동작**: 이전에도 controller mode에서 실행되지 않았고, 변경 후에도 실행되지 않음
- **프로젝트 저장/로드**: `iframeworkspace`를 통해 부모 iframe(jce-class-rails)과 postMessage로 통신하는 방식 그대로 유지
- **인증 흐름**: `webapp/src/auth.ts`의 dummy 인증(`DUMMY_LOGGED_IN`, `DUMMY_USER_PROFILE`)은 그대로 유지

### 런타임 에러 가능성
- `Cloud.apiRoot`는 origin 로직에 따라 현재 호스트 기반(`{origin}/api/`)으로 설정됨
- 이 값은 cloud sync 코드에서만 사용되는데, 위 분석대로 cloud sync 코드는 실행되지 않음
- 따라서 새로운 런타임 에러 발생 가능성 없음

## 후속 작업 (별도 작업)

이 PR과 별개로 origin과 다른 부분이 추가로 존재합니다. 향후 origin 따라잡기 작업을 위해 정리하면 다음과 같습니다.

| 카테고리 | 파일 | 비고 |
|---------|------|------|
| 쿠키 인증 | `pxtlib/codle/cookie.ts` (신규), `pxtlib/auth.ts`, `webapp/src/auth.ts` | 코들 쿠키 기반 인증으로 교체 (필수) |
| GitHub proxy | `pxtlib/github.ts` | makecode.com으로 직접 라우팅 ([TeamMonolith] 마커) |
| Cloud sync | `webapp/src/cloud.ts` | remote 삭제 처리 (TASK-5245) |
| 확장 메뉴 | `localtypings/pxteditor.d.ts`, `pxteditor/editorcontroller.ts`, `app.tsx`, `container.tsx` | TASK-5524 |
| UI 디브랜딩 | `headerbar.tsx`, `container.tsx`, `index.html` | 로고/메뉴 숨김 |
| 패키지/CI | `package.json`, `.github/workflows/*.disabled`, `README.md` | 패키지명/CI 변경 |

이 PR은 그 중에서 **cloud sync를 위해 추가했던 class-rails apiRoot 커스텀 설정**만 정리합니다.

## Test plan
- [x] \`npx tsc -p webapp/tsconfig.json --noEmit\` — app.tsx 관련 컴파일 에러 0건 확인
- [ ] 개발환경 배포 후 controller mode에서 기존 동작(프로젝트 로드/저장/실행) 정상 확인
- [ ] BE의 version 제거 PR과 함께 통합 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)