### PR TITLE
feat(TASK-5546): hideExtensionMenu 제거 및 pxt-core 0.8.0

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -237,8 +237,6 @@ declare namespace pxt.editor {
         filters?: ProjectFilters;
         // (optional) show or hide the search bar
         searchBar?: boolean;
-        // AIDEV-NOTE: TASK-5524 codle-react에서 iframe 내 확장 메뉴 숨김 제어를 위해 추가한 로컬 전용 속성 (원본 pxt에 없음)
-        hideExtensionMenu?: boolean;
     }
 
     export interface EditorWorkspaceSyncResponse extends EditorMessageResponse {
@@ -839,8 +837,6 @@ declare namespace pxt.editor {
         filters?: pxt.editor.ProjectFilters;
         searchBar?: boolean; // show the search bar in editor
         hasCategories?: boolean; // show categories in toolbox
-        // AIDEV-NOTE: TASK-5524 codle-react에서 iframe 내 확장 메뉴 숨김 제어를 위해 추가한 로컬 전용 속성 (원본 pxt에 없음)
-        hideExtensionMenu?: boolean;
     }
 
     export interface ExampleImportOptions {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-monolith/pxt-core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
## 요약 (TASK-5546)

TASK-5524에서 추가했던 fork 전용 속성 `hideExtensionMenu`를 제거하고, `@team-monolith/pxt-core` 버전을 `0.8.0`으로 올립니다. pxt-microbit v8 작업 과정에서 확장 메뉴는 항상 노출하는 방향으로 정책이 바뀌었습니다.

## 변경 내용

- `localtypings/pxteditor.d.ts`
  - `EditorSyncState.hideExtensionMenu` 제거
  - `EditorState.hideExtensionMenu` 제거
  - 두 곳 모두 `// AIDEV-NOTE: TASK-5524 ...` 코멘트 함께 삭제
- `package.json`
  - `@team-monolith/pxt-core` `0.7.1` → `0.8.0`

> pxt 내부에서 이 필드를 읽는 코드는 없으며 (consumer는 codle-react/pxt-microbit), 그 쪽 정리는 후속 작업에서 진행합니다.

## 의존/배포

- 이 PR의 base는 #20 의 머지 브랜치(`microsoft-upstream-260410+main`)입니다. **#20 머지 후 이 PR도 머지** 가능.
- 머지 후 `@team-monolith/pxt-core@0.8.0` npm publish는 작업자(@shcshcshc)가 직접 진행합니다.
- 후속: pxt-microbit에서 `@team-monolith/pxt-core@0.8.0` 의존성 업데이트 및 `hideExtensionMenu` consumer 제거.

## 관련 PR

- #19 — \[VIEW\] upstream 대비 커스텀 변경사항
- #20 — pxt-core v12.3.5 upstream merge (선행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)